### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2024"
 license = "MIT"
 readme = "README.md"
 version = "0.1.9"
-repository = "https://www.github.com/kasandell/hibachi"
+repository = "https://github.com/kasandell/hibachi"
 authors = [
     "Kyle Sandell"
 ]


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
